### PR TITLE
Update storeAsIntervals API

### DIFF
--- a/lib/intervals.js
+++ b/lib/intervals.js
@@ -68,9 +68,10 @@ function enrichInterval (user, bmrPerInt, intervalSize, method, interval) {
 }
 
 // Calulate intervals, enrich with user data, delete old ones, then save.
-module.exports.storeAsIntervals = function (db, startDate, endDate, activities, user, method, intervalSize, done) {
+module.exports.storeAsIntervals = function ({ db, startDate, endDate, activities, user, method, intervalSize, intervals }, done) {
   const bmrPerInt = kp.bmrPerInterval(user, intervalSize)
-  const intervals = calcIntervals({ startDate, endDate, activities, intervalSize })
+  // calculate intervals from activities if they haven't been passed in
+  intervals = (intervals || calcIntervals({ startDate, endDate, activities, intervalSize }))
     .map(enrichInterval.bind(null, user, bmrPerInt, intervalSize, method))
 
   let bulkIntervals = db.intervals.initializeUnorderedBulkOp()

--- a/lib/kudos-points.js
+++ b/lib/kudos-points.js
@@ -35,8 +35,7 @@ function kudosPoints ({ cals, user, bmrPerInt, date, intervalSize, method }) {
       return ratio * 100 * intervalDayPortion
 
     case 'fitbit':
-      if (cals > (bmrPerInt * 2)) return (cals / (bmrPerInt + cals)) * 100 * intervalDayPortion
-      return 0
+      return Math.max(0, ((cals - bmrPerInt) / (cals || 1))) * 100 * intervalDayPortion
 
     default:
       return (cals / (bmrPerInt + cals)) * 100 * intervalDayPortion

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kudoshealth-lib",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Library functions for KudosHealth API and data project",
   "private": true,
   "main": "index.js",


### PR DESCRIPTION
Updates the `storeAsInterval` method to take an object for the majority of params, and allows intervals to be passed directly into the method rather than having it calculate them itself, so that we avoid doing extra work when the Fitbit intraday API provides us with nice 15 minute chunks.

Also updates the Fitbit KudosPoints calculation to take into account the new data (which is already filtered for active minutes, and includes calories due to BMR).