### PR TITLE
Fixes rankings helpers

### DIFF
--- a/lib/member-rankings.js
+++ b/lib/member-rankings.js
@@ -48,6 +48,7 @@ function getGroupRankings (db, group, members, sinceDate, cb) {
       if (err) return cb(err)
       cb(null, {
         userId: member._id,
+        members: [member._id],
         name: `${member.firstName} ${member.lastName}`,
         active: member.active,
         activated: member.activated,
@@ -57,7 +58,7 @@ function getGroupRankings (db, group, members, sinceDate, cb) {
     })
   }, (err, rankings) => {
     if (err) return cb(err)
-    cb(null, rankings.sort(sortByScore))
+    cb(null, addRank(rankings.sort(sortByScore)))
   })
 }
 
@@ -67,4 +68,11 @@ function sortByScore (a, b) {
   if (a.name < b.name) return 1
   if (a.name > b.name) return -1
   return 0
+}
+
+function addRank (docs) {
+  return docs.map((doc, ind) => {
+    doc.ranking = ind
+    return doc
+  })
 }

--- a/lib/team-rankings.js
+++ b/lib/team-rankings.js
@@ -34,15 +34,16 @@ module.exports.get = ({ db, group, sinceDate }, cb) => {
           const score = rankings.length ? Math.round((total / rankings.length) * 10) / 10 : 0
 
           return {
-            _id: team._id,
             name: team.name,
+            userId: team._id,
+            members: team.members.map((m) => m.user),
             startDate: team.startDate,
             endDate: team.endDate,
             score
           }
         })
 
-        cb(null, rankings.sort(sortByScore))
+        cb(null, addRank(rankings.sort(sortByScore)))
       })
     }
   ], cb)
@@ -54,4 +55,11 @@ function sortByScore (a, b) {
   if (a.name < b.name) return 1
   if (a.name > b.name) return -1
   return 0
+}
+
+function addRank (docs) {
+  return docs.map((doc, ind) => {
+    doc.ranking = ind
+    return doc
+  })
 }


### PR DESCRIPTION
Ensures every standing returned has a `userId` (`user._id` or `team._id`) and a `ranking` field for comparison with the previous day's results.