### PR TITLE
Adds panels to team league leaderboards

### DIFF
--- a/lib/team-rankings.js
+++ b/lib/team-rankings.js
@@ -17,7 +17,7 @@ module.exports.get = ({ db, group, sinceDate }, cb) => {
     function getTeams (teamIdDocs, cb) {
       const teamIds = teamIdDocs.map((doc) => doc.teamId)
       const query = { _id: { $in: teamIds }, deleted: false }
-      const fields = { members: 1, name: 1, startDate: 1 }
+      const fields = { members: 1, name: 1, startDate: 1, panel: 1 }
 
       db.groups.find(query, fields, cb)
     },

--- a/lib/team-rankings.js
+++ b/lib/team-rankings.js
@@ -39,6 +39,7 @@ module.exports.get = ({ db, group, sinceDate }, cb) => {
             members: team.members.map((m) => m.user),
             startDate: team.startDate,
             endDate: team.endDate,
+            panel: team.panel,
             score
           }
         })


### PR DESCRIPTION
Panels are now denormalised onto team docs, but not retrieved in or supplied by the team ranking function, which makes the process somewhat pointless.  This PR corrects that.