### PR TITLE
Add activity names to intervals

### DIFF
--- a/lib/intervals.js
+++ b/lib/intervals.js
@@ -1,3 +1,4 @@
+const activityNames = require('activity-names')
 const moment = require('moment')
 const kp = require('./kudos-points')
 const chunkedOp = require('./chunked-op')
@@ -17,34 +18,54 @@ const chunkedOp = require('./chunked-op')
         intervalSize (number): the desired size of each interval in ms
       }
     Returns:
-      {
+      [{
         startDate (number): start of the interval in ms since epoch,
         endDate (number); end of the interval in ms since epoch,
         calories (number): total calories expended during this interval (across all activities)
-      }
+        types (array): normalised activity names during this interval
+      }]
 */
 const calcIntervals = function ({ startDate, endDate, activities, intervalSize }) {
   if (!activities) return []
   let intervals = []
   for (let time = startDate; time < endDate; time += intervalSize) {
     let endTime = time + intervalSize
-    let calories = activities.map(caloriesInPeriod.bind(null, time, endTime)).reduce((x, y) => x + y, 0)
+    let {calories, types} = dataInPeriod(time, endTime, activities)
     if (calories) {
       intervals.push({
         startDate: time,
         endDate: endTime,
-        calories
+        calories,
+        types
       })
     }
   }
   return intervals
 }
 
-function caloriesInPeriod (startDate, endDate, activity) {
+// (num, num, arr) => {calories: 36, types: ['Running']}
+// Type name are ordered with the longest running activity first.
+function dataInPeriod (startDate, endDate, activities) {
+  return activities
+    .map((a) => ({activity: a, ms: activeMillisInPeriod(startDate, endDate, a)}))
+    .sort((a, b) => b.ms - a.ms)
+    .reduce((res, {ms, activity}) => {
+      if (!ms || !activity.calsPerMilli) return res
+      const calories = activity.calsPerMilli * ms
+      // normalise the name of the activity for our intervals
+      const type = activityNames(activity.type)
+      return {
+        calories: res.calories + calories,
+        types: res.types.concat([type])
+      }
+    }, {calories: 0, types: []})
+}
+
+function activeMillisInPeriod (startDate, endDate, activity) {
   const startMillis = Math.max(startDate, activity.startDate)
   const endMillis = Math.min(endDate, activity.endDate)
   const overlapMillis = Math.max(endMillis - startMillis, 0)
-  return overlapMillis * activity.calsPerMilli
+  return overlapMillis
 }
 
 function enrichInterval (user, bmrPerInt, intervalSize, method, interval) {

--- a/lib/intervals.js
+++ b/lib/intervals.js
@@ -53,7 +53,7 @@ function dataInPeriod (startDate, endDate, activities) {
       if (!ms || !activity.calsPerMilli) return res
       const calories = activity.calsPerMilli * ms
       // normalise the name of the activity for our intervals
-      const type = activityNames(activity.type)
+      const type = activity.type ? activityNames(activity.type) : 'Activity'
       return {
         calories: res.calories + calories,
         types: res.types.concat([type])

--- a/lib/intervals.js
+++ b/lib/intervals.js
@@ -56,7 +56,7 @@ function dataInPeriod (startDate, endDate, activities) {
       const type = activity.type ? activityNames(activity.type) : 'Activity'
       return {
         calories: res.calories + calories,
-        types: res.types.concat([type])
+        types: res.types.indexOf(type) < 0 ? res.types.concat([type]) : res.types
       }
     }, {calories: 0, types: []})
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/tableflip/kudoshealth-lib#readme",
   "dependencies": {
+    "activity-names": "^1.0.4",
     "async": "^2.0.1",
     "moment": "^2.14.1"
   },

--- a/tests/intervals.js
+++ b/tests/intervals.js
@@ -1,0 +1,38 @@
+const test = require('tape')
+const moment = require('moment')
+const calcIntervals = require('..').intervals.calcIntervals
+
+test('Should calculate intervals', (t) => {
+  const start = moment('2017-01-10T10:00:00Z')
+  const activities = [
+    {
+      startDate: moment(start).add(14, 'minutes').valueOf(),
+      endDate: moment(start).add(16, 'minutes').valueOf(),
+      calsPerMilli: 0.01,
+      type: 'Ride'
+    },
+    {
+      startDate: moment(start).add(15, 'minutes').valueOf(),
+      endDate: moment(start).add(20, 'minutes').valueOf(),
+      calsPerMilli: 0.02,
+      type: 'Run'
+    }
+  ]
+  const startDate = start.valueOf()
+  const endDate = moment(start).add(4, 'hours').valueOf()
+  const intervalSize = 1000 * 60 * 15
+
+  // DO IT!
+  const intervals = calcIntervals({startDate, endDate, activities, intervalSize})
+
+  t.equal(intervals.length, 2, 'Found 2 intervals with activity')
+  t.equal(intervals[0].startDate, startDate, 'interval times as expected')
+  t.equal(intervals[0].endDate, moment(startDate).add(intervalSize, 'ms').valueOf(), 'interval times as expected')
+  t.equal(intervals[1].startDate, moment(startDate).add(intervalSize, 'ms').valueOf(), 'interval times as expected')
+  t.equal(intervals[1].endDate, moment(startDate).add(2 * intervalSize, 'ms').valueOf(), 'interval times as expected')
+  t.equal(intervals[0].calories, 1000 * 60 * 0.01, 'Calories calc as expected')
+  t.equal(intervals[1].calories, (1000 * 60 * 0.01) + (1000 * 60 * 5 * 0.02), 'Calories calc as expected')
+  t.deepEqual(intervals[0].types, ['Cycling'], 'Activity names are normalised')
+  t.deepEqual(intervals[1].types, ['Running', 'Cycling'], 'Activity names are ordered by duration')
+  t.end()
+})

--- a/tests/intervals.js
+++ b/tests/intervals.js
@@ -16,6 +16,16 @@ test('Should calculate intervals', (t) => {
       endDate: moment(start).add(20, 'minutes').valueOf(),
       calsPerMilli: 0.02,
       type: 'Run'
+    },
+    {
+      startDate: moment(start).add(30, 'minutes').valueOf(),
+      endDate: moment(start).add(35, 'minutes').valueOf(),
+      calsPerMilli: 0.03
+    },
+    {
+      startDate: moment(start).add(35, 'minutes').valueOf(),
+      endDate: moment(start).add(40, 'minutes').valueOf(),
+      calsPerMilli: 0.04
     }
   ]
   const startDate = start.valueOf()
@@ -25,7 +35,7 @@ test('Should calculate intervals', (t) => {
   // DO IT!
   const intervals = calcIntervals({startDate, endDate, activities, intervalSize})
 
-  t.equal(intervals.length, 2, 'Found 2 intervals with activity')
+  t.equal(intervals.length, 3, 'Found 3 intervals with activity')
   t.equal(intervals[0].startDate, startDate, 'interval times as expected')
   t.equal(intervals[0].endDate, moment(startDate).add(intervalSize, 'ms').valueOf(), 'interval times as expected')
   t.equal(intervals[1].startDate, moment(startDate).add(intervalSize, 'ms').valueOf(), 'interval times as expected')
@@ -34,5 +44,6 @@ test('Should calculate intervals', (t) => {
   t.equal(intervals[1].calories, (1000 * 60 * 0.01) + (1000 * 60 * 5 * 0.02), 'Calories calc as expected')
   t.deepEqual(intervals[0].types, ['Cycling'], 'Activity names are normalised')
   t.deepEqual(intervals[1].types, ['Running', 'Cycling'], 'Activity names are ordered by duration')
+  t.deepEqual(intervals[2].types, ['Activity'], 'Activity name is defaulted and de-duped')
   t.end()
 })


### PR DESCRIPTION
Update `calcIntervals` to record the normalised activity names on the interval. The name are stored on a property called `types` and the value is an array of strings that are the (en_gb) human friendly names, ordered so the activity that occurred for longest in the interval comes first.

Uses https://github.com/tableflip/fitness-activity to normalise the names where sensible.