### PR TITLE
Guards against empty arrays

### DIFF
--- a/lib/member-rankings.js
+++ b/lib/member-rankings.js
@@ -24,7 +24,7 @@ function getGroupMembers (db, group, cb) {
   db.users.find(query, fields, (err, users) => {
     if (err) return cb(err)
     cb(null, users.map((user) => {
-      let member = group.members.find((m) => m.user.equals(user._id))
+      let member = group.members.find((m) => m.user && m.user.equals && m.user.equals(user._id))
       return Object.assign({}, member, user)
     }))
   })


### PR DESCRIPTION
This PR fixes an issue where we iterate on an empty array and try to call `ObjectId.equals(objectId)` on undefined